### PR TITLE
Remove extranous reqOptions param in getLogoutUrl

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -269,7 +269,7 @@ function addVetumaLangExtension(parentTag, lang) {
 }
 /*jshint +W069 */
 
-SAML.prototype.generateLogoutRequest = function (req, reqOptions) {
+SAML.prototype.generateLogoutRequest = function (req, options) {
   var id = "_" + this.generateUniqueID();
   var instant = this.generateInstant();
 
@@ -307,8 +307,8 @@ SAML.prototype.generateLogoutRequest = function (req, reqOptions) {
     };
   }
 
-  if (reqOptions && reqOptions.vetumaLang) {
-    addVetumaLangExtension(request['samlp:LogoutRequest'], reqOptions.vetumaLang);
+  if (options && options.vetumaLang) {
+    addVetumaLangExtension(request['samlp:LogoutRequest'], options.vetumaLang);
   }
 
   return xmlbuilder.create(request).end();
@@ -516,8 +516,8 @@ SAML.prototype.getAuthorizeForm = function (req, reqOptions, callback) {
 
 };
 
-SAML.prototype.getLogoutUrl = function(req, options, reqOptions, callback) {
-  var request = this.generateLogoutRequest(req, reqOptions);
+SAML.prototype.getLogoutUrl = function(req, options, callback) {
+  var request = this.generateLogoutRequest(req, options);
   var operation = 'logout';
   var overrideParams = options ? options.additionalParams || {} : {};
   this.requestToUrl(request, null, operation, this.getAdditionalParams(req, operation, overrideParams), callback);

--- a/test/samlTests.js
+++ b/test/samlTests.js
@@ -4,8 +4,6 @@ var SAML = require('../lib/passport-saml/saml.js').SAML;
 var should = require('should');
 var url = require('url');
 
-var reqOptions = null
-
 // Start suomifi additions
 //
 // few checks are enforced by default in suomifi-passport-saml. In order to be able to run default (unmodified)
@@ -94,31 +92,31 @@ describe('SAML.js', function () {
 
     describe('getLogoutUrl', function () {
       it('calls callback with right host', function (done) {
-        saml.getLogoutUrl(req, {}, reqOptions, function (err, target) {
+        saml.getLogoutUrl(req, {}, function (err, target) {
           url.parse(target).host.should.equal('exampleidp.com');
           done();
         });
       });
       it('calls callback with right protocol', function (done) {
-        saml.getLogoutUrl(req, {}, reqOptions, function (err, target) {
+        saml.getLogoutUrl(req, {}, function (err, target) {
           url.parse(target).protocol.should.equal('https:');
           done();
         });
       });
       it('calls callback with right path', function (done) {
-        saml.getLogoutUrl(req, {}, reqOptions, function (err, target) {
+        saml.getLogoutUrl(req, {}, function (err, target) {
           url.parse(target).pathname.should.equal('/path');
           done();
         });
       });
       it('calls callback with original query string', function (done) {
-        saml.getLogoutUrl(req, {}, reqOptions, function (err, target) {
+        saml.getLogoutUrl(req, {}, function (err, target) {
           url.parse(target, true).query['key'].should.equal('value');
           done();
         });
       });
       it('calls callback with additional run-time params in query string', function (done) {
-        saml.getLogoutUrl(req, options, reqOptions, function (err, target) {
+        saml.getLogoutUrl(req, options, function (err, target) {
           Object.keys(url.parse(target, true).query).should.have.length(3);
           url.parse(target, true).query['key'].should.equal('value');
           url.parse(target, true).query['SAMLRequest'].should.not.be.empty();
@@ -128,7 +126,7 @@ describe('SAML.js', function () {
       });
       // NOTE: This test only tests existence of the assertion, not the correctness
       it('calls callback with saml request object', function (done) {
-        saml.getLogoutUrl(req, {}, reqOptions, function (err, target) {
+        saml.getLogoutUrl(req, {}, function (err, target) {
           should(url.parse(target, true).query).have.property('SAMLRequest');
           done();
         });


### PR DESCRIPTION
Applying changes from previous fork to newer version of passport-saml added extra params to getLogoutUrl which were not needed and were erroneous.