### PR TITLE
Remove InResponseTo if validation fails

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -344,7 +344,7 @@ SAML.prototype.generateLogoutResponse = function (req, logoutRequest) {
 SAML.prototype.requestToUrl = function (request, response, operation, additionalParameters, callback) {
   var self = this;
   if (self.options.skipRequestCompression)
-    requestToUrlHelper(null, new Buffer(request || response, 'utf8'));
+    requestToUrlHelper(null, Buffer.from(request || response, 'utf8'));
   else
     zlib.deflateRaw(request || response, requestToUrlHelper);
 
@@ -508,7 +508,7 @@ SAML.prototype.getAuthorizeForm = function (req, reqOptions, callback) {
     }
 
     if (self.options.skipRequestCompression) {
-      getAuthorizeFormHelper(null, new Buffer(request, 'utf8'));
+      getAuthorizeFormHelper(null, Buffer.from(request, 'utf8'));
     } else {
       zlib.deflateRaw(request, getAuthorizeFormHelper);
     }
@@ -620,7 +620,7 @@ SAML.prototype.validatePostResponse = function (container, callback) {
   var xml, doc, inResponseTo;
 
   Q.fcall(function(){
-    xml = new Buffer(container.SAMLResponse, 'base64').toString('utf8');
+    xml = Buffer.from(container.SAMLResponse, 'base64').toString('utf8');
     doc = new xmldom.DOMParser({
     }).parseFromString(xml);
 
@@ -885,7 +885,7 @@ SAML.prototype.validateRedirect = function(container, callback) {
   var self = this;
   var samlMessageType = container.SAMLRequest ? 'SAMLRequest' : 'SAMLResponse';
 
-  var data = new Buffer(container[samlMessageType], "base64");
+  var data = Buffer.from(container[samlMessageType], "base64");
   zlib.inflateRaw(data, function(err, inflated) {
     if (err) {
       return callback(err);
@@ -1289,7 +1289,7 @@ SAML.prototype.checkAudienceValidityError = function(expectedAudience, audienceR
 
 SAML.prototype.validatePostRequest = function (container, callback) {
   var self = this;
-  var xml = new Buffer(container.SAMLRequest, 'base64').toString('utf8');
+  var xml = Buffer.from(container.SAMLRequest, 'base64').toString('utf8');
   var dom = new xmldom.DOMParser().parseFromString(xml);
   var parserConfig = {
     explicitRoot: true,

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -859,7 +859,10 @@ SAML.prototype.validatePostResponse = function (container, callback) {
   })
   .fail(function(err) {
     debug('validatePostResponse resulted in an error: %s', err);
-    callback(err);
+    Q.ninvoke(self.cacheProvider, 'remove', inResponseTo)
+      .then(function() {
+        callback(err);
+    });
   })
   .done();
 };

--- a/test/suomifiAdditionsTest.js
+++ b/test/suomifiAdditionsTest.js
@@ -300,6 +300,26 @@ describe( 'suomifi additions for passport-saml /', function() {
         });
       });
 
+      it('must remove InResponseTo value if response validation fails', function (done) {
+
+        const samlConfig = createBaselineSAMLConfiguration();
+        samlConfig.cert = [];
+
+        const base64xml = Buffer.from(
+          assertTruthy(testData.SIGNED_MESSAGE_SIGNED_ENCRYPTED_ASSERTION_VALID_LOGIN_RESPONSE)
+        ).toString('base64');
+        const container = {SAMLResponse: base64xml};
+        const samlObj = new SAML(samlConfig);
+        samlObj.validatePostResponse(container, function (err, profile) {
+          should.exist(err);
+          should.not.exist(profile);
+          err.message.should.match('Invalid top level signature');
+          samlObj.validatePostResponse(container, function (err, profile) {
+            err.message.should.match('InResponseTo is not valid');
+            done();
+          });
+        });
+      });
     });
 
     describe("validate suomifi additions checks /", function () {


### PR DESCRIPTION
InResponseTo value should be removed if signature validation fails.

Add test to verify this.

This PR will also fix Node deprecation "[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead."