### PR TITLE
Remove InResponseTo value if response validation fails

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -859,7 +859,10 @@ SAML.prototype.validatePostResponse = function (container, callback) {
   })
   .fail(function(err) {
     debug('validatePostResponse resulted in an error: %s', err);
-    callback(err);
+    Q.ninvoke(self.cacheProvider, 'remove', inResponseTo)
+      .then(function() {
+        callback(err);
+    });
   })
   .done();
 };

--- a/test/suomifiAdditionsTest.js
+++ b/test/suomifiAdditionsTest.js
@@ -300,6 +300,26 @@ describe( 'suomifi additions for passport-saml /', function() {
         });
       });
 
+      it('must remove InResponseTo value if response validation fails', function (done) {
+
+        const samlConfig = createBaselineSAMLConfiguration();
+        samlConfig.cert = [];
+
+        const base64xml = Buffer.from(
+          assertTruthy(testData.SIGNED_MESSAGE_SIGNED_ENCRYPTED_ASSERTION_VALID_LOGIN_RESPONSE)
+        ).toString('base64');
+        const container = {SAMLResponse: base64xml};
+        const samlObj = new SAML(samlConfig);
+        samlObj.validatePostResponse(container, function (err, profile) {
+          should.exist(err);
+          should.not.exist(profile);
+          err.message.should.match('Invalid top level signature');
+          samlObj.validatePostResponse(container, function (err, profile) {
+            err.message.should.match('InResponseTo is not valid');
+            done();
+          });
+        });
+      });
     });
 
     describe("validate suomifi additions checks /", function () {


### PR DESCRIPTION
InResponseTo value is used to verify that the response is for a valid request. If InResponseTo doesn't match a request the response is invalid. This is a cheap verification before more expensive cryptographical validation.

If cryptographical validation fails the response is most likely invalid and the corresponding InResponseTo value should be removed so no further calls can be made using it.