### PR TITLE
Add option to use idp public key for signature validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ type Profile = {
   * `additionalLogoutParams`: dictionary of additional query params to add to 'logout' requests
   * `logoutCallbackUrl`: The value with which to populate the `Location` attribute in the `SingleLogoutService` elements in the generated service provider metadata.
  * **Suomi.fi Additions**
-  * `suomifiAdditions`: contains (debug) flags which can be used to turn off certain suomi.fi specific SAML (login) response checks / policy enforcements
+  * `suomifiAdditions`: contains (debug) flags which can be used to turn off certain suomi.fi specific SAML (login) response checks / policy enforcements / configurations.
 
 ### Suomi.fi Additions
 
@@ -163,7 +163,8 @@ suomifiAdditions = {
   disableValidateInResponseEnforcementForUnitTestingPurposes:  false,
   disablePostResponseTopLevelSignatureValidationEnforcementForUnitTestPurposes: false,
   disableAssertionSignatureVerificationEnforcementForUnitTestPurposes: false,
-  disableAudienceCheckEnforcementForUnitTestPurposes: false
+  disableAudienceCheckEnforcementForUnitTestPurposes: false,
+  usePublicKeyAsCertParamForSignatureValidation: false
 }
 ```
 i.e. these additional checks / policy enforcements are enabled by default

--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -86,6 +86,10 @@ SAML.prototype.initialize = function (options) {
   if (!options.suomifiAdditions.disableAudienceCheckEnforcementForUnitTestPurposes) {
     options.suomifiAdditions.disableAudienceCheckEnforcementForUnitTestPurposes = false;
   }
+
+  if (!options.suomifiAdditions.usePublicKeyAsCertParamForSignatureValidation) {
+    options.suomifiAdditions.usePublicKeyAsCertParamForSignatureValidation = false;
+  }
   // End suomifi additions configuration parameters
 
   if(!options.validateInResponseTo){
@@ -541,6 +545,11 @@ SAML.prototype.getLogoutResponseUrl = function(req, options, callback) {
 
 SAML.prototype.certToPEM = function (cert) {
   cert = cert.match(/.{1,64}/g).join('\n');
+  // Start suomifi additions
+  var self = this;
+  if (self.options.suomifiAdditions.usePublicKeyAsCertParamForSignatureValidation)
+    return this.keyToPEM(cert);
+  // End suomifi additions
 
   if (cert.indexOf('-BEGIN CERTIFICATE-') === -1)
     cert = "-----BEGIN CERTIFICATE-----\n" + cert;
@@ -549,6 +558,17 @@ SAML.prototype.certToPEM = function (cert) {
 
   return cert;
 };
+
+// Start suomifi additions
+SAML.prototype.keyToPEM = function(key) {
+  if (key.indexOf('-BEGIN PUBLIC KEY-') === -1)
+    key = "-----BEGIN PUBLIC KEY-----\n" + key;
+  if (key.indexOf('-END PUBLIC KEY-') === -1)
+    key = key + "\n-----END PUBLIC KEY-----\n";
+
+  return key;
+};
+// End suomifi additions
 
 SAML.prototype.certsToCheck = function () {
   var self = this;
@@ -985,7 +1005,7 @@ SAML.prototype.validateSignatureForRedirect = function (urlString, signature, al
 
   var verifier = crypto.createVerify(supportedAlgs[supportedAlgs.length-1]);
   verifier.update(urlString);
-  
+
   return verifier.verify(this.certToPEM(cert), signature, 'base64');
 };
 

--- a/test/suomifiGeneratedTestData.js
+++ b/test/suomifiGeneratedTestData.js
@@ -87,7 +87,26 @@ lrhFfreYoDJMZkupF+BVOROVZPpI5TOeThIsuVumk9hR34mvsoqGlbP8cSXd9KJx
 -----END CERTIFICATE-----`;
 
 /**
- * Private key of "uknown SP" (i.e. key of "some other" SP)
+ *
+ * @type {string}
+ */
+testData.IDP_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAumoRKMchYJomYFVKRFbF
++nt1SK8siEjrFjfRBI4D5TQaZUobnmBGWXQ8pDPJPFAs2+UZpFSLRqZHziuO/YH9
+cVfe9qRJL9JEHy0KRWiOI+r7008clLjFc/GT1L3jHoCjfPex7+jGTpb7bEo9P+BE
+Q1bnytqOVQPiwYsnPKH38/xqu8Lo9kxM9rMWhvaM+Ut9LY59+XDSiYCQDcdKyg6M
+gptDR5Ym3qZFdFGLOLUrRIPSS+kZ/ee6uQtm5n2Rf1+WrU37vPayqB4ADZ6rHWIy
+hvPyRZm6r4QKSPJhSQQHBdNJ5U4d6EKOGFc52iLcuZmtVBEMJ3F3V97NyU3C/GEo
+aSJG0DcYqq+CLQ9m9GZcF3iEpdibR84vnLFjC4OdsukoYzmx/nEOf0cZfxa6VfIz
+B+CZ9gibP7Bx55QT3K+b99/vKd1WwUHogzt+GckXCJCfufYpxdrtZPu9jJD+2oVz
+RhyhijyqZeFVX5Kf9X+j1D4MrwKEDcCVX+oJ6fNjgIWPPpNsrZ/Z1Td9gTQQ3Tn+
+378B85o9uWpfNPW1WgJTHai8JV2MtVG1XeoTJuIKqMI5LM3oTK3mnulDu4gQxIFl
+sQyNB33ExWIbelcP9o9iSFouyg9j+otX0uLnh/Hv9EBy5T5r1FgwlK1zvIUWYsvU
+GtN+L4HXW9oDzK3Yot2N/KMCAwEAAQ==
+-----END PUBLIC KEY-----`
+
+/**
+ * Private key of "unknown SP" (i.e. key of "some other" SP)
  *
  * @type {string}
  */


### PR DESCRIPTION
Add functionality to be able to use identity providers public key for signature validation instead of public certificate since some idps are unable to produce the certificate.

Feature is turned on by setting `options.suomifiAdditions.usePublicKeyAsCertParamForSignatureValidation = true` which allows public key to be used instead of certificate as `options.cert` parameter.
