### PR TITLE
Pass 'options' to generateLogoutRequest so that vetuma-extension is preserved

### DIFF
--- a/lib/passport-saml/saml.js
+++ b/lib/passport-saml/saml.js
@@ -528,7 +528,7 @@ SAML.prototype.getAuthorizeForm = function (req, reqOptions, callback) {
 };
 
 SAML.prototype.getLogoutUrl = function(req, options, callback) {
-  return this.generateLogoutRequest(req)
+  return this.generateLogoutRequest(req, options)
     .then(request => {
       const operation = 'logout';
       const overrideParams = options ? options.additionalParams || {} : {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suomifi-passport-saml",
-  "version": "1.3.3-sfi.0",
+  "version": "1.3.3-sfi.1",
   "license": "MIT",
   "keywords": [
     "saml",


### PR DESCRIPTION
Mainline passport-saml has dropped the 'options' from the generateLogoutRequest function call, which means that options.vetumaLang gets dropped and the logoutrequest no longer has vetuma-extension. This in turn means that Single Logout page won't be localized correctly.